### PR TITLE
Retrait de règles CSS inutiles

### DIFF
--- a/grid/grid_position/style.css
+++ b/grid/grid_position/style.css
@@ -1,7 +1,6 @@
 .conteneur {
     display: grid;
     grid-template-columns: 0.25fr 1fr 0.25fr;
-    grid-auto-rows: repeat(2, 1fr);
 }
 
 .conteneur>div {

--- a/grid/grid_template_areas/style.css
+++ b/grid/grid_template_areas/style.css
@@ -4,8 +4,6 @@
                          "un deux trois"
                          "un quatre quatre";
     grid-template-columns: 0.25fr 1fr 0.25fr;
-    grid-auto-rows: repeat(3, 1fr);
-    
 }
 
 .conteneur>div {


### PR DESCRIPTION
Retrait de la règle invalide `grid-auto-rows: repeat(2, 1fr);`

Le fait de déclarer le nombre de colonnes et avoir plus d'enfants que de colonnes va automatiquement générer le bon nombre de rangées.