### PR TITLE
Exemple d'attribut box-sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ Contient différents exemples de positionnement à l'aide de l'attribut `positio
 
 Contient des exemples de la gestion du débordement du contenu d'un élément.
 
-Le fichier [`percentage.html`](./layout/percentage.html) contient un exemple des problèmes potentiels de l'utilisation de pourcentages pour des éléments ayant des `margin` et `padding`, ex : `width : 100%`.
+Le fichier [percentage.html](./layout/percentage.html) contient un exemple des problèmes potentiels de l'utilisation de pourcentages pour des éléments ayant des `margin` et `padding`, ex : `width : 100%`.
 
-Le fichier [`overflow.html`](./layout/overflow.html) contient des exemples de l'utilisation de l'attribut `overflow` pour contrôler l'affichage du contenu qui dépasse la taille de son parent.
+Le fichier [box-sizing.html](./layout/box-sizing.html) contient un exemple de l'utilisation de la propriété `box-sizing` pour contrôler la taille d'un élément en incluant ou excluant les marges et les bordures.
+
+Le fichier [overflow.html](./layout/overflow.html) contient des exemples de l'utilisation de l'attribut `overflow` pour contrôler l'affichage du contenu qui dépasse la taille de son parent.
 
 ## [flexbox](./flexbox/)
 

--- a/layout/box-sizing.html
+++ b/layout/box-sizing.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Exemple de box-sizing</title>
+  <style>
+    #externe {
+      width: 200px;
+      height: 200px;
+      border: solid 10px red;
+      padding: 20px;
+      margin: 10px;
+    }
+
+    #interne {
+      border: solid 10px blue;
+      height: 160px;
+      width: 100%;
+      box-sizing: border-box;
+    }
+
+    section {
+      background-size: 10px 10px;
+      background-image:
+        linear-gradient(to right, #80808020 1px, transparent 1px),
+        linear-gradient(to bottom, #80808020 1px, transparent 1px);
+    }
+  </style>
+</head>
+
+<body>
+  <section>
+    <h3>Boîte interne à 100% avec <code>box-sizing: border-box;</code></h3>
+    <div id="externe">
+      <div id="interne"></div>
+    </div>
+  </section>
+</body>
+
+</html>


### PR DESCRIPTION
Ajout d'exemple d'attribut `box-sizing` pour ajuster un élément interne en fonction de ses attributs `width` et `height` ainsi que l'impact de `margin` et `border`.

Le code CSS est directement dans le HTML pour réduire le nombre de fichiers différents nécessaires.

Idée originale de l'exemple par @EmilioRivera 