### PR TITLE
feat: Improve box-sizing example with animations and box content

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Contient des exemples de la gestion du débordement du contenu d'un élément.
 
 Le fichier [percentage.html](./layout/percentage.html) contient un exemple des problèmes potentiels de l'utilisation de pourcentages pour des éléments ayant des `margin` et `padding`, ex : `width : 100%`.
 
-Le fichier [box-sizing.html](./layout/box-sizing.html) contient un exemple de l'utilisation de la propriété `box-sizing` pour contrôler la taille d'un élément en incluant ou excluant les marges et les bordures.
+Le fichier [box-sizing.html](./layout/box-sizing.html) contient un exemple de l'utilisation de la propriété `box-sizing` pour contrôler la taille d'un élément en incluant ou excluant les marges et les bordures. L'exemple permet de jouer avec les différentes propriétés de la boîte pour voir leur effet sur la taille de l'élément dans les outils de développement du navigateur.
 
 Le fichier [overflow.html](./layout/overflow.html) contient des exemples de l'utilisation de l'attribut `overflow` pour contrôler l'affichage du contenu qui dépasse la taille de son parent.
 

--- a/layout/box-sizing.html
+++ b/layout/box-sizing.html
@@ -37,8 +37,8 @@
       /* Jouez avec ces parametres */
       box-sizing: border-box;
       /* border-width: 10px; */
-      /* margin: 25px; */
       /* padding: 0px 20px; */
+      /* margin: 25px; */
     }
   </style>
 </head>
@@ -46,7 +46,14 @@
 <body>
   <section>
     <h3>Boîte interne à 100% avec <code>box-sizing: border-box;</code></h3>
-    <p>Ouvrez l'éditeur de style et jouez avec les paramètres de la boite interne!</p>
+    <p>Ouvrez l'éditeur de style et jouez avec les paramètres de la boîte interne : </p>
+    <h2><code>border-width</code>, <code>margin</code> et <code>padding</code> </h2>
+    <p>Modifiez également les valeurs de <code>box-sizing</code> et <code>width</code> pour voir les effets sur la boîte
+      interne. Par exemple : </p>
+    <section style="display: flex; flex-direction: column; gap: 5px; margin-bottom: 10px; align-items: center;">
+      <code>box-sizing: border-box; width: 100%; margin: 25px;</code> VS
+      <code>box-sizing: border-box; width: auto; margin: 0px;</code>
+    </section>
     <div id="externe">
       <div id="interne">MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM</div>
     </div>

--- a/layout/box-sizing.html
+++ b/layout/box-sizing.html
@@ -9,23 +9,36 @@
     #externe {
       width: 200px;
       height: 200px;
-      border: solid 10px red;
-      padding: 20px;
-      margin: 10px;
+      border-width: 0px;
+      border-color: red;
+      border-style: solid;
+
+      /* Jouez avec ces parametres */
+      /* border-width: 10px; */
+      /* padding: 20px; */
+      /* margin: 10px; */
+
+      /* Ajout pour mieux voir */
+      outline: 2px dotted rebeccapurple;
+      transition: all 1s ease-in;
     }
 
     #interne {
-      border: solid 10px blue;
       height: 160px;
+      width: auto;
       width: 100%;
-      box-sizing: border-box;
-    }
+      word-wrap: break-word;
+      transition: 1s ease-in;
+      transition-property: all;
 
-    section {
-      background-size: 10px 10px;
-      background-image:
-        linear-gradient(to right, #80808020 1px, transparent 1px),
-        linear-gradient(to bottom, #80808020 1px, transparent 1px);
+      outline: 1px dashed red;
+      border: solid 0px blue;
+
+      /* Jouez avec ces parametres */
+      box-sizing: border-box;
+      /* border-width: 10px; */
+      /* margin: 25px; */
+      /* padding: 0px 20px; */
     }
   </style>
 </head>
@@ -33,8 +46,9 @@
 <body>
   <section>
     <h3>Boîte interne à 100% avec <code>box-sizing: border-box;</code></h3>
+    <p>Ouvrez l'éditeur de style et jouez avec les paramètres de la boite interne!</p>
     <div id="externe">
-      <div id="interne"></div>
+      <div id="interne">MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM</div>
     </div>
   </section>
 </body>


### PR DESCRIPTION
Meilleure visibilité de `box-sizing` via l'ajout d'animation sur les propriétés CSS des boîtes. Nous n'avons plus besoin des "gridlines" donc je les ai enlevées. J'ai aussi ajouté du contenu dans la boite interne pour mieux voir l'effet de box-sizing.

À noter qu'il est attendu que les étudiants jouent avec les propriétés _dans le fureteur directement_ (via la "DevConsole") afin de pouvoir voir les animations.